### PR TITLE
cli option to run migrations only and then exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,19 +175,20 @@ The following CLI options are available:
 
 ```
 Options:
-  --help            Show help                                          [boolean]
-  --version         Show version number                                [boolean]
-  --connection, -c  Database connection string, defaults to the 'DATABASE_URL'
-                    envvar                                              [string]
-  --once, -1        Run until there are no runnable jobs left, then exit
+  --help              Show help                                          [boolean]
+  --version           Show version number                                [boolean]
+  --connection, -c    Database connection string, defaults to the 'DATABASE_URL'
+                      envvar                                              [string]
+  --once, -1          Run until there are no runnable jobs left, then exit
                                                       [boolean] [default: false]
-  --watch, -w       [EXPERIMENTAL] Watch task files for changes, automatically
-                    reloading the task code without restarting worker
+  --watch, -w         [EXPERIMENTAL] Watch task files for changes, automatically
+                      reloading the task code without restarting worker
                                                       [boolean] [default: false]
-  --jobs, -j        number of jobs to run concurrently              [default: 1]
-  --poll-interval   how long to wait between polling for jobs in milliseconds
-                    (for jobs scheduled in the future/retries)
+  --jobs, -j          number of jobs to run concurrently              [default: 1]
+  --poll-interval     how long to wait between polling for jobs in milliseconds
+                      (for jobs scheduled in the future/retries)
                                                         [number] [default: 2000]
+  --migrate-only, -m  Run migrations and then exit
 ```
 
 ## Library usage

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ import getTasks from "./getTasks";
 export * from "./interfaces";
 
 export { runTaskList, runTaskListOnce } from "./main";
-export { run, runOnce } from "./runner";
+export { migrateOnly, run, runOnce } from "./runner";
 
 export { getTasks };

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -59,6 +59,11 @@ const processOptions = async (options: RunnerOptions) => {
   }
 };
 
+export const migrateOnly = async (options: RunnerOptions): Promise<void> => {
+  const { release } = await processOptions(options);
+  await release();
+};
+
 export const runOnce = async (options: RunnerOptions): Promise<void> => {
   const { taskList, withPgClient, release } = await processOptions(options);
   await withPgClient(client => runTaskListOnce(taskList, client, options));


### PR DESCRIPTION
Adds CLI capability to run all graphile worker database migrations and then exit.